### PR TITLE
接入coveralls自动测试代码覆盖率

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 .idea
 .DS_Store
 .nyc_output
-conf
-log
+/conf
+/coverage
+/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ node_js:
 
 script:
   - npm run lint
-  - npm test && npm run coverage
+  - npm run coverage
+after_success:
+  - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
   - "9"
-
+cache:
+  directories:
+    - node_modules
 script:
   - npm run lint
   - npm run coverage

--- a/bin/tsw/util/Queue/index.js
+++ b/bin/tsw/util/Queue/index.js
@@ -38,7 +38,7 @@ Queue.prototype.queue = function(fn){
 
 Queue.prototype.dequeue = function(){
 	
-    var domain,that,fn;
+    var domain,fn;
 	
     if(this._queue.length === 0){
         return this;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint": "eslint examples bin/wwwroot bin/proxy bin/tsw bin/lib test --fix",
     "precommit": "lint-staged",
-    "test": "mocha --recursive test/bin",
+    "test": "mocha test/**/*.js",
     "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "precommit": "lint-staged",
     "test": "mocha --recursive test/bin",
     "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test",
-    "coveralls": "coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "lint": "eslint examples bin/wwwroot bin/proxy bin/tsw bin/lib test --fix",
     "precommit": "lint-staged",
-    "test": "mocha test/**/*.js",
+    "test": "mocha --recursive test/bin",
     "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "lint": "eslint examples bin/wwwroot bin/proxy bin/tsw bin/lib test --fix",
     "precommit": "lint-staged",
     "test": "mocha --recursive test/bin",
-    "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test"
+    "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test",
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -19,14 +20,15 @@
     "memcached": "~0.2.8"
   },
   "devDependencies": {
-    "plug": "file:./bin/plug",
     "chai": "^4.1.2",
-    "mocha": "^5.0.5",
-    "nyc": "^11.6.0",
-    "sinon": "^4.1.2",
+    "coveralls": "^3.0.1",
     "eslint": "^4.10.0",
     "husky": "^0.14.3",
-    "lint-staged": "^7.0.0"
+    "lint-staged": "^7.0.0",
+    "mocha": "^5.0.5",
+    "nyc": "^11.6.0",
+    "plug": "file:./bin/plug",
+    "sinon": "^4.1.2"
   },
   "optionalDependencies": {
     "heapdump": "^0.3.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint": "eslint examples bin/wwwroot bin/proxy bin/tsw bin/lib test --fix",
     "precommit": "lint-staged",
     "test": "mocha --recursive test/bin",
-    "coverage": "nyc mocha --recursive test/bin"
+    "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. 增加coveralls 支持
2. ignore相关覆盖率结果文件
3. travis只执行node 9，并增加目录缓存
4. 解决eslint报错