### PR TITLE
chore: add .npmrc to avoid making package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "TSW",
   "version": "1.1.0",
+  "description": "A Node.js infrastructure which is designed for improving the efficiency of locating problems, providing multiple functions for front-end developers",
   "scripts": {
     "lint": "eslint examples bin test --fix",
     "precommit": "lint-staged",


### PR DESCRIPTION
# chore: add .npmrc to avoid make package-lock.json

如果选择信赖第三方库，不予锁定版本，那么增加`.npmrc`配置文件，避免`npm install`的时候产生`package-lock.json`文件

关于`package-lock.json`的[讨论](https://www.zhihu.com/question/264560841)

# chore: add `description` to package.json to avoid WARN when npm install

避免这个WARN
![image](https://user-images.githubusercontent.com/4194287/40498071-847ca794-5fb0-11e8-94e1-3526e8b81c59.png)
