### PR TITLE
fix(sea-node): do not use cache when `options` has `paths` property

### DIFF
--- a/bin/tsw/loader/seajs/lib/sea-node.js
+++ b/bin/tsw/loader/seajs/lib/sea-node.js
@@ -12,12 +12,14 @@ const _compile = Module.prototype._compile;
 const _resolveFilename = Module._resolveFilename;
 const moduleStack = [];
 
-Module._resolveFilename = function(request, parent) {
+Module._resolveFilename = function(request, parent, isMain, options = {}) {
     let res;
     //request = request.replace(/\?.*$/, '') // remove timestamp etc.
 
     //性能优化
-    if(parent.resolveFilenameCache) {
+    // do not use cache when `options` has `paths` property
+    // in v8.9.0 require.resolve case
+    if(parent.resolveFilenameCache && !options.paths) {
         if(parent.resolveFilenameCache[request]) {
             return parent.resolveFilenameCache[request];
         }
@@ -25,7 +27,7 @@ Module._resolveFilename = function(request, parent) {
         parent.resolveFilenameCache = {};
     }
 
-    res = _resolveFilename(request, parent);
+    res = _resolveFilename(request, parent, isMain, options);
 
     parent.resolveFilenameCache[request] = res;
 


### PR DESCRIPTION
avoid problems in v8.9.0 require.resolve case

**Checklist:**

- [x] test cases has added or updated
- [ ] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

# 测试用例
```js
"use strict";

console.time(1);

for(var i = 0; i < 100000; i++){
	require('./require.cpu.empty.js');
}

const a = require.resolve('./require.cpu.empty.js', {paths: []}) // 这里正常会报错

console.timeEnd(1);

var Module = module.constructor;
var _resolveFilename = Module._resolveFilename

Module._resolveFilename = function(request, parent) {
  var res;
  
  //性能优化
  if(parent.resolveFilenameCache){
    if(parent.resolveFilenameCache[request]){
      return parent.resolveFilenameCache[request]
    }
  }else{
  	parent.resolveFilenameCache = {};
  }
  
  res = _resolveFilename(request, parent, isMain, options);
  
  parent.resolveFilenameCache[request] = res;
  
  return res;
}

console.time('2');

for(var i = 0; i < 100000; i++){
	require('./require.cpu.empty.js');
}

const b = require.resolve('./require.cpu.empty.js', {paths: []}) // 这里期望是报错，但是其实用了缓存结果，所以实际不会报错

console.timeEnd('2');

```