### PR TITLE
允许在启动参数中指定config文件的路径

### DIFF
--- a/conf/config.js
+++ b/conf/config.js
@@ -1,4 +1,18 @@
-module.exports = require('../examples/framework/config.js');
+/* !
+ * Tencent is pleased to support the open source community by making Tencent Server Web available.
+ * Copyright (C) 2018 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
 
-//module.exports = require('../examples/skyMode/config.js');
+const processArgs = plug('util/process.args.js');
 
+let configPath = '../examples/framework/config.js';
+
+if (typeof processArgs.config === 'string') {
+    configPath = processArgs.config;
+}
+
+module.exports = require(configPath);


### PR DESCRIPTION
**Checklist:**

- [ * ] test cases has added or updated
- [ * ] documentation has added or updated
- [ * ] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

TSW的配置文件支持在启用的时候传入参数
例如在诸如WebStorm、Visual Studio Code中就可以这样配置，以实现选择不同的项目调试：
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "request": "launch",
            "name": "TSW(photo.v7)",
            "program": "${workspaceFolder}/TSW/index.js",
            "args": [
                "config=../../photo.v7/nodejs/server/conf/dev/config.js"
            ]
        },
        {
            "type": "node",
            "request": "launch",
            "name": "TSW(git-hook)",
            "program": "${workspaceFolder}/TSW/index.js",
            "args": [
                "config=../../git-hook/config.js"
            ]
        }
    ]
}
```
