### PR TITLE
fix(websocket): log message length instead of message body

### DIFF
--- a/bin/proxy/websocket.js
+++ b/bin/proxy/websocket.js
@@ -195,8 +195,8 @@ function bind_listen(server) {
 
             ws.on('message', function(message) {
                 ws.messageTriggerCount++;
-                logger.debug('server get message : ${message}', {
-                    message
+                logger.debug('server get message size : ${size}', {
+                    size: message.length
                 });
                 tnm2.Attr_API('SUM_TSW_WEBSOCKET_MESSAGE', 1);
 


### PR DESCRIPTION
**Checklist:**

- [ ] test cases has added or updated
- [ ] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)
