### PR TITLE
feat: add TSW_CONFIG_PATH env

### DIFF
--- a/bin/proxy/config.js
+++ b/bin/proxy/config.js
@@ -28,6 +28,8 @@ if (global[__filename]) {
 
 if (typeof processArgs.config === 'string') {
     cache.config = require(path.resolve(cwd, processArgs.config));
+} else if (typeof process.env.TSW_CONFIG_PATH === 'string') {
+    cache.config = require(process.env.TSW_CONFIG_PATH);
 } else if (fs.existsSync(currConfig)) {
     cache.config = require(currConfig);
 } else if (fs.existsSync('/etc/tsw.config.js')) {


### PR DESCRIPTION
在读取全局配置文件的时候，增加对环境变量`TSW_CONFIG_PATH`，如果有此环境变量，那么会读取这个变量的值当做配置文件的地址

**Checklist:**

- [ ] test cases has added or updated
- [ ] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)
