### PR TITLE
chore(docker): add nodejs-npm for building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-RUN apk --update --no-cache add procps git nodejs bash gawk
+RUN apk --update --no-cache add procps git nodejs nodejs-npm bash gawk
 RUN git clone https://github.com/Tencent/TSW.git /TSW
 WORKDIR /TSW
 VOLUME /data/release/node_modules/


### PR DESCRIPTION
**Checklist:**

- [x] test cases has added or updated
- [x] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

alpine linux上的nodejs已经不再包含nodejs-npm，需要解决创建docker image时出现错误。