### PR TITLE
feat: add ignoreSIGTERM config

### DIFF
--- a/bin/proxy/master.js
+++ b/bin/proxy/master.js
@@ -504,6 +504,12 @@ function masterEventHandler() {
             }
         }
     });
+
+    if (config.ignoreSIGTERM) {
+        process.on('SIGTERM', () => {
+            logger.info('Received SIGTERM signal from system, but ignore it. This message usually indicates that TSW is running in a container.');
+        });
+    }
 }
 
 function startMasterMonitor() {

--- a/bin/tsw/default/config.default.js
+++ b/bin/tsw/default/config.default.js
@@ -168,3 +168,5 @@ this.tswL5api['cmem.tsw.sh'] = this.tswL5api['cmem.tsw.sz'];
 this.tswL5api['cmem.tsw.tj'] = this.tswL5api['cmem.tsw.sh'];
 this.tswL5api['cmem.tsw.h5test'] = this.tswL5api['cmem.tsw.sz'];
 
+// 指定一个布尔值，表明TSW Master进程是否忽略来自系统的SIGTERM信号
+this.ignoreSIGTERM = false;


### PR DESCRIPTION
**Checklist:**

- [x] test cases has added or updated
- [x] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

在配置文件中增加`ignoreSIGTERM`属性。如果它的值为true，在TSW主进程运行过程中会忽略来自系统的`SIGTERM`信号。在kubernetes中可以配合`terminationGracePeriodSeconds`属性使用。