### PR TITLE
fix: 修复node 12.4.0以后require相对上级目录无法找到模块的问题

### DIFF
--- a/bin/tsw/loader/seajs/lib/sea-node.js
+++ b/bin/tsw/loader/seajs/lib/sea-node.js
@@ -13,13 +13,13 @@ const _resolveFilename = Module._resolveFilename;
 const moduleStack = [];
 
 
-Module._resolveFilename = function(request, parent, isMain, options = {}) {
+Module._resolveFilename = function(request, parent, isMain, options) {
     // request = request.replace(/\?.*$/, '') // remove timestamp etc.
 
     // 性能优化
     // do not use cache when `options` has `paths` property
     // in v8.9.0 require.resolve case
-    if (parent.resolveFilenameCache && !options.paths) {
+    if (parent.resolveFilenameCache && options && !options.paths) {
         if (parent.resolveFilenameCache[request]) {
             return parent.resolveFilenameCache[request];
         }


### PR DESCRIPTION
**Checklist:**

- [x] test cases has added or updated
- [x] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

由于node源码对loader.js的[改动](https://github.com/nodejs/node/commit/a608caa5ffb428994c4f508b426d25dae2dbda54)，在调用`_resolveFilename`时`options`传入一个空对象`{}`会导致在判断条件时出现错误。为了解决这个问题在hack `_resolveFilename`方法的时候需要做到不变更`options`的值。