### PR TITLE
fix: remove uninstallHacks

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,5 +45,4 @@ export default async (
 
   installHacks();
   await import(path.resolve(basePath, mainPath));
-  uninstallHacks();
 };


### PR DESCRIPTION
**Checklist:**

- [x] test cases has added or updated
- [x] documentation has added or updated
- [x] commit message follows the [convention commit guidelines](https://conventionalcommits.org/)

```javascript
   installHacks();
   await import(path.resolve(basePath, mainPath));
   uninstallHacks();
```
在 lib/index.ts中,由于await import文件中,再次hacks了console对象。由于是异步事件，当uninstallHacks()执行之后，console对象不存在originxx的属性方法。
```javascript

    console.info = (
      message?: any,
      ...optionalParams: any[]
    ): void => {
      if (getCurrentContext() === null) {
        return console.originInfo(message, ...optionalParams);
      }

      return logger.writeLog(
        "INFO",
        `${util.format(message, ...optionalParams)}`
      );
    };
```
这个时候,await语句中存在的异步事件调用hacks之后的console.info。由于console对象已经删除originInfo,所以报错。因此，需要去掉uninstallHacks()。