### PR TITLE
fix(domain): 清理domain的时候，移除挂载在domain的context

### DIFF
--- a/lib/core/runtime/create-server.hack.ts
+++ b/lib/core/runtime/create-server.hack.ts
@@ -64,6 +64,10 @@ export const hack = <T extends typeof http.createServer>(
           d.remove(req);
           d.remove(res);
 
+          if (process.domain.currentContext) {
+            process.domain.currentContext = null;
+          }
+
           const parser = (req.socket as any).parser as any;
           if (parser && parser.domain) {
             (parser.domain as domain.Domain).exit();


### PR DESCRIPTION
"nodejs里面EventEmitter初始化的时候，都会把当前的domain存下来。然后tsw里面又把整个请求的抓包存在domain.currentContext. 而数据库的PoolConnection类型又是继承EventEmitter的，Connection会一直存在，所以内存里就会一直有最初启动的几条流水线日志抓包。"